### PR TITLE
fix typo in sample grapheme definition

### DIFF
--- a/srfi-115.html
+++ b/srfi-115.html
@@ -1540,7 +1540,7 @@ string has been mutated is unspecified.
         (+ ,char-set:regional-indicator)
         (: "\r\n")
         (: (~ control ("\r\n"))
-           (+ ,char-set:mark))
+           (* ,char-set:mark))
         control)
 </pre>
 


### PR DESCRIPTION
The text says "zero or more combining marks," the sample definition should match this.  One or more is clearly a bug and deserving of an errata.